### PR TITLE
Verify minimum Python before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ developing your own Add-ons.
 
 The Add-on Example Generator requires the following software to be installed on your machine:
 
-- Python 3.8 or later
+- Python 3.11 or later available on your path as either `python` or `python3`
 - Node.js 21.7.3 or later
 - On Windows, make sure that long paths are enabled both in Windows RegEdit and Git.
 	- You can enable long paths in the Windows RegEdit by running the following command in PowerShell as an

--- a/addon_template/_dev_tools/addon_tasks/bootstrap.py
+++ b/addon_template/_dev_tools/addon_tasks/bootstrap.py
@@ -9,7 +9,6 @@ from _dev_tools.addon_tasks.utils import (
     get_module,
     parse_url_username_password,
     save_json,
-    check_python_version,
     CREDENTIALS_JSON_FILE,
 )
 

--- a/addon_template/_dev_tools/addon_tasks/bootstrap.py
+++ b/addon_template/_dev_tools/addon_tasks/bootstrap.py
@@ -9,8 +9,11 @@ from _dev_tools.addon_tasks.utils import (
     get_module,
     parse_url_username_password,
     save_json,
-    CREDENTIALS_JSON_FILE
+    check_python_version,
+    CREDENTIALS_JSON_FILE,
 )
+
+from _dev_tools.utils import check_python_version, MIN_PYTHON_VERSION
 
 
 def bootstrap(args):
@@ -27,9 +30,6 @@ def bootstrap(args):
 
 
 def check_dependencies(element_paths_with_type: Dict[str, str]):
-    python_version = sys.version_info
-    if python_version < (3, 11):
-        raise Exception('Python 3.11 or higher is required.')
-    print(f'Python version: {python_version.major}.{python_version.minor}.{python_version.micro}')
+    check_python_version(*MIN_PYTHON_VERSION)
     for element_path, element_type in element_paths_with_type.items():
         get_module(element_path, element_type).check_dependencies()

--- a/addon_template/_dev_tools/addon_tasks/utils.py
+++ b/addon_template/_dev_tools/addon_tasks/utils.py
@@ -13,50 +13,40 @@ from stat import FILE_ATTRIBUTE_HIDDEN
 from _dev_tools.addon_tasks.element_protocol import ElementProtocol
 
 PROJECT_PATH = pathlib.Path(__file__).parent.parent.parent.resolve()
-WHEELS_PATH = PROJECT_PATH / ".wheels"
-DIST_FOLDER = PROJECT_PATH / "dist"
+WHEELS_PATH = PROJECT_PATH / '.wheels'
+DIST_FOLDER = PROJECT_PATH / 'dist'
 ADDON_JSON_FILE = PROJECT_PATH / "addon.json"
-ADD_ON_EXTENSION = ".addon"
+ADD_ON_EXTENSION = '.addon'
 CREDENTIALS_JSON_FILE = PROJECT_PATH / ".credentials.json"
 
-ELEMENT_ACTION_FILE = "element"
+ELEMENT_ACTION_FILE = 'element'
 
 IDENTIFIER = "identifier"
-VERSION = "version"
-ELEMENTS = "elements"
-ELEMENT_PATH = "path"
-ELEMENT_TYPE = "type"
-ELEMENT_IDENTIFIER = "identifier"
+VERSION = 'version'
+ELEMENTS = 'elements'
+ELEMENT_PATH = 'path'
+ELEMENT_TYPE = 'type'
+ELEMENT_IDENTIFIER = 'identifier'
 CONFIGURATION_SCHEMA = "configuration_schema"
 PREVIEWS = "previews"
 
 ADD_ON_TOOL_TYPE = "AddOnTool"
-DEFAULT_ADD_ON_TOOL_ELEMENT_PATH = (
-    f"{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project"
-)
+DEFAULT_ADD_ON_TOOL_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project'
 DISPLAY_PANE_PLUGIN_TYPE = "Plugin"
-DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH = (
-    f"{pathlib.Path(__file__).parent.parent.name}.defaults.plugin"
-)
+DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.plugin'
 TOOL_PANE_PLUGIN_TYPE = "Plugin"
-DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH = (
-    f"{pathlib.Path(__file__).parent.parent.name}.defaults.plugin"
-)
+DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.plugin'
 FORMULA_PACKAGE_TYPE = "FormulaPackage"
-DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH = (
-    f"{pathlib.Path(__file__).parent.parent.name}.defaults.formula_package"
-)
+DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.formula_package'
 DATA_LAB_FUNCTIONS_TYPE = "DataLabFunctions"
-DATA_LAB_FUNCTIONS_ELEMENT_PATH = (
-    f"{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project"
-)
+DATA_LAB_FUNCTIONS_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project'
 
-TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
 NOTE_FOR_FEATURE_FLAG_CHANGE = "Enabled by Add-on Packaging Utility"
 
 
 def save_json(path: pathlib.Path, values: dict) -> None:
-    with open(path, mode="w", encoding="utf-8") as json_file:
+    with open(path, mode='w', encoding='utf-8') as json_file:
         json.dump(values, json_file, indent=2, ensure_ascii=False)
 
 
@@ -64,10 +54,10 @@ def load_json(path: pathlib.Path) -> Optional[dict]:
     if not path.exists():
         return None
     try:
-        with open(path, mode="r", encoding="utf-8") as json_file:
+        with open(path, mode='r', encoding='utf-8') as json_file:
             return json.load(json_file)
     except json.JSONDecodeError:
-        raise Exception(f"Error loading JSON file: {path}")
+        raise Exception(f'Error loading JSON file: {path}')
 
 
 def get_credentials_json() -> Optional[dict]:
@@ -98,47 +88,35 @@ def get_module(element_path: str, element_type: str) -> ElementProtocol:
         if path in sys.modules:
             return sys.modules[path]
         return importlib.import_module(path)
-
     try:
-        module = load_module(f"{element_path}.{ELEMENT_ACTION_FILE}")
+        module = load_module(f'{element_path}.{ELEMENT_ACTION_FILE}')
         assert isinstance(module, ElementProtocol)
         return module
     except ModuleNotFoundError:
         if element_type == ADD_ON_TOOL_TYPE:
-            module = load_module(
-                f"{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
-            )
+            module = load_module(f"{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == FORMULA_PACKAGE_TYPE:
-            module = load_module(
-                f"{DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
-            )
+            module = load_module(f"{DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == DISPLAY_PANE_PLUGIN_TYPE:
-            module = load_module(
-                f"{DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
-            )
+            module = load_module(f"{DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == TOOL_PANE_PLUGIN_TYPE:
-            module = load_module(
-                f"{DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
-            )
+            module = load_module(f"{DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == DATA_LAB_FUNCTIONS_TYPE:
-            module = load_module(
-                f"{DATA_LAB_FUNCTIONS_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
-            )
+            module = load_module(f"{DATA_LAB_FUNCTIONS_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
             assert isinstance(module, ElementProtocol)
             return module
         else:
             raise ModuleNotFoundError(
-                f"Neither {element_path}.{ELEMENT_ACTION_FILE} nor "
-                f"{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE} were found"
-            )
+                f'Neither {element_path}.{ELEMENT_ACTION_FILE} nor '
+                f'{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE} were found')
 
 
 def get_folders_from_args(args) -> Optional[List[str]]:
@@ -146,7 +124,7 @@ def get_folders_from_args(args) -> Optional[List[str]]:
         return None
     for folder in args.dir:
         if not (PROJECT_PATH / pathlib.Path(folder)).exists():
-            raise Exception(f"Folder does not exist: {folder}")
+            raise Exception(f'Folder does not exist: {folder}')
     return [str(pathlib.Path(folder)) for folder in args.dir]
 
 
@@ -154,13 +132,10 @@ def get_element_paths_with_type() -> Dict[str, str]:
     add_on_json = get_add_on_json()
     if add_on_json is None or ELEMENTS not in add_on_json:
         return {}
-    element_paths = {
-        element.get(ELEMENT_PATH): element.get(ELEMENT_TYPE)
-        for element in add_on_json.get(ELEMENTS)
-    }
+    element_paths = {element.get(ELEMENT_PATH): element.get(ELEMENT_TYPE) for element in add_on_json.get(ELEMENTS)}
     for element_path in element_paths:
         if not pathlib.Path(element_path).exists():
-            raise Exception(f"Element path does not exist: {element_path}")
+            raise Exception(f'Element path does not exist: {element_path}')
     return element_paths
 
 
@@ -173,10 +148,10 @@ def get_files_to_package() -> List[str]:
 def parse_url_username_password(args=None):
     credentials_json = {}
     if (
-        args is None
-        or args.username is None
-        or args.password is None
-        or args.url is None
+            args is None
+            or args.username is None
+            or args.password is None
+            or args.url is None
     ):
         credentials_json = get_credentials_json()
         if credentials_json is None:
@@ -210,17 +185,11 @@ def get_element_identifier_from_path(element_path: pathlib.Path) -> str:
     )
 
 
-def filter_element_paths(
-    element_paths_with_type: Optional[Dict[str, str]],
-    subset_folders: Optional[List[str]],
-):
+def filter_element_paths(element_paths_with_type: Optional[Dict[str, str]], subset_folders: Optional[List[str]]):
     if subset_folders is None:
         return element_paths_with_type
-    return {
-        element_path: element_type
-        for element_path, element_type in element_paths_with_type.items()
-        if element_path in subset_folders
-    }
+    return {element_path: element_type for element_path, element_type in element_paths_with_type.items()
+            if element_path in subset_folders}
 
 
 def topological_sort(graph: Dict[str, List[str]]) -> List[str]:
@@ -296,7 +265,6 @@ def generate_schema_default_dict(schema, path=""):
 
 def check_feature_is_enabled(url, username, password, feature_path):
     from seeq import sdk, spy
-
     spy.login(username=username, password=password, url=url, quiet=True)
     system_api = sdk.SystemApi(spy.client)
     response = system_api.get_server_status()
@@ -305,34 +273,28 @@ def check_feature_is_enabled(url, username, password, feature_path):
             if option.value is False:
                 if spy.user.is_admin:
                     print(f"Feature {feature_path} is not enabled. Enabling it now.")
-                    system_api.set_configuration_options(
-                        body={
-                            "configurationOptions": [
-                                {
-                                    "note": NOTE_FOR_FEATURE_FLAG_CHANGE,
-                                    "path": feature_path,
-                                    "value": True,
-                                }
-                            ],
-                            "dryRun": False,
-                        }
-                    )
+                    system_api.set_configuration_options(body={
+                        "configurationOptions": [
+                            {
+                                "note": NOTE_FOR_FEATURE_FLAG_CHANGE,
+                                "path": feature_path,
+                                "value": True
+                            }
+                        ],
+                        "dryRun": False
+                    })
                 else:
                     raise ValueError(
-                        f"Feature {feature_path} is not enabled. Please contact your Seeq administrator to enable it"
-                    )
+                        f"Feature {feature_path} is not enabled. Please contact your Seeq administrator to enable it")
 
 
 def _get_authenticated_session(element_path, url, username, password):
     from seeq import sdk, spy
-
     spy.login(username=username, password=password, url=url, quiet=True)
-    auth_header = {"sq-auth": spy.client.auth_token}
+    auth_header = {'sq-auth': spy.client.auth_token}
     items_api = sdk.ItemsApi(spy.client)
     element_project_name = get_element_identifier_from_path(element_path)
-    response = items_api.search_items(
-        filters=[f"name=={element_project_name}"], types=["Project"]
-    )
+    response = items_api.search_items(filters=[f'name=={element_project_name}'], types=['Project'])
     if len(response.items) == 0:
         raise Exception(f"Could not find a project with name {element_project_name}")
     project_id = response.items[0].id
@@ -343,65 +305,39 @@ def _get_authenticated_session(element_path, url, username, password):
 def _create_requests_session():
     import requests
     from requests.adapters import HTTPAdapter, Retry
-
     max_request_retries = 5
     request_retry_status_list = [502, 503, 504]
     _http_adapter = HTTPAdapter(
-        max_retries=Retry(
-            total=max_request_retries,
-            backoff_factor=0.5,
-            status_forcelist=request_retry_status_list,
-        )
-    )
+        max_retries=Retry(total=max_request_retries, backoff_factor=0.5, status_forcelist=request_retry_status_list))
     request_session = requests.Session()
     request_session.mount("http://", _http_adapter)
     request_session.mount("https://", _http_adapter)
     return request_session
 
 
-def _upload_file(
-    server_url, request_session, auth_header, project_id, source, destination
-):
+def _upload_file(server_url, request_session, auth_header, project_id, source, destination):
     from requests.exceptions import RetryError
 
     jupyter_path = _get_jupyter_contents_api_path(server_url, project_id, destination)
     base_name = os.path.basename(source)
-    with open(source, "rb") as file:
-        contents = file.read() or b""
-    body = json.dumps(
-        {
-            "path": jupyter_path.replace("//", r"/"),
-            "content": base64.b64encode(contents).decode("ascii"),
-            "format": "base64",
-            "name": base_name,
-            "type": "file",
-        }
-    )
+    with open(source, 'rb') as file:
+        contents = file.read() or b''
+    body = json.dumps({'path': jupyter_path.replace('//', r'/'),
+                       'content': base64.b64encode(contents).decode('ascii'),
+                       'format': 'base64',
+                       'name': base_name,
+                       'type': 'file'})
     response = None
     try:
-        response = request_session.put(
-            jupyter_path,
-            data=body,
-            headers=auth_header,
-            cookies=auth_header,
-            verify=True,
-            timeout=60,
-        )
+        response = request_session.put(jupyter_path, data=body, headers=auth_header, cookies=auth_header,
+                                       verify=True, timeout=60)
     except RetryError:
         pass
     if response is None or response.status_code == 500:
-        _upload_directory(
-            server_url, request_session, auth_header, project_id, destination
-        )
+        _upload_directory(server_url, request_session, auth_header, project_id, destination)
         try:
-            response = request_session.put(
-                jupyter_path,
-                data=body,
-                headers=auth_header,
-                cookies=auth_header,
-                verify=True,
-                timeout=60,
-            )
+            response = request_session.put(jupyter_path, data=body, headers=auth_header, cookies=auth_header,
+                                           verify=True, timeout=60)
         except RetryError:
             pass
 
@@ -411,85 +347,46 @@ def _upload_file(
 
 def _upload_directory(server_url, request_session, auth_header, project_id, full_path):
     from requests.exceptions import RetryError
-
     path_parts = pathlib.Path(full_path).parts
     paths_to_create = [list(path_parts[:i]) for i in range(1, len(path_parts))]
-    body = json.dumps({"type": "directory"})
-    base = [server_url, "data-lab", project_id, "api", "contents"]
+    body = json.dumps({'type': 'directory'})
+    base = [server_url, 'data-lab', project_id, 'api', 'contents']
     for path in paths_to_create:
         try:
-            request_session.put(
-                "/".join(base + path),
-                data=body,
-                headers=auth_header,
-                cookies=auth_header,
-                verify=True,
-                timeout=60,
-            )
+            request_session.put('/'.join(base + path), data=body,
+                                headers=auth_header, cookies=auth_header,
+                                verify=True, timeout=60)
         except RetryError:
             pass
 
 
-def _delete_file(
-    server_url, request_session, auth_header, project_id, source, destination
-):
+def _delete_file(server_url, request_session, auth_header, project_id, source, destination):
     from requests.exceptions import RetryError
-
     base_name = os.path.basename(source)
     jupyter_path = _get_jupyter_contents_api_path(server_url, project_id, destination)
     response = None
     try:
-        response = request_session.delete(
-            jupyter_path,
-            headers=auth_header,
-            cookies=auth_header,
-            verify=True,
-            timeout=60,
-        )
+        response = request_session.delete(jupyter_path,
+                                          headers=auth_header, cookies=auth_header,
+                                          verify=True, timeout=60)
     except RetryError:
         pass
     status = "Success" if (response is not None) else "Failure"
     print(f"    {_get_timestamp()} Attempt to delete {base_name} : {status}")
 
 
-async def _watch_from_environment(
-    element_path: pathlib.Path,
-    url: str,
-    username: str,
-    password: str,
-    file_extensions: set,
-    excluded_files: set,
-    excluded_folders: set,
-):
+async def _watch_from_environment(element_path: pathlib.Path, url: str, username: str, password: str,
+                                  file_extensions: set, excluded_files: set, excluded_folders: set):
     print(f"Watching {element_path}")
-    await asyncio.gather(
-        hot_reload(
-            element_path,
-            url,
-            username,
-            password,
-            file_extensions,
-            excluded_files,
-            excluded_folders,
-        )
-    )
+    await asyncio.gather(hot_reload(element_path, url, username, password,
+                                    file_extensions, excluded_files, excluded_folders))
 
 
-async def hot_reload(
-    element_path: pathlib.Path,
-    url: str,
-    username: str,
-    password: str,
-    file_extensions: set,
-    excluded_files: set,
-    excluded_folders: set,
-):
+async def hot_reload(element_path: pathlib.Path, url: str, username: str, password: str,
+                     file_extensions: set, excluded_files: set, excluded_folders: set):
 
     from watchfiles import awatch, Change
-
-    requests_session, auth_header, project_id = _get_authenticated_session(
-        element_path, url, username, password
-    )
+    requests_session, auth_header, project_id = _get_authenticated_session(element_path, url, username, password)
     async for changes in awatch(element_path):
         for change in changes:
             if isdir(change[1]):
@@ -499,60 +396,38 @@ async def hot_reload(
             absolute_file_path = change[1]
             destination = relpath(absolute_file_path, element_path)
 
-            if file_matches_criteria(
-                str(element_path),
-                absolute_file_path,
-                file_extensions=file_extensions,
-                excluded_files=excluded_files,
-                excluded_folders=excluded_folders,
-            ):
+            if file_matches_criteria(str(element_path),
+                                     absolute_file_path,
+                                     file_extensions=file_extensions,
+                                     excluded_files=excluded_files,
+                                     excluded_folders=excluded_folders):
                 if deleted:
-                    _delete_file(
-                        url,
-                        requests_session,
-                        auth_header,
-                        project_id,
-                        absolute_file_path,
-                        destination,
-                    )
+                    _delete_file(url, requests_session, auth_header, project_id,
+                                 absolute_file_path, destination)
                 else:
-                    _upload_file(
-                        url,
-                        requests_session,
-                        auth_header,
-                        project_id,
-                        absolute_file_path,
-                        destination,
-                    )
+                    _upload_file(url, requests_session, auth_header, project_id,
+                                 absolute_file_path, destination)
                 _shut_down_kernel(url, requests_session, auth_header, project_id)
 
 
-def file_matches_criteria(
-    root: str,
-    file: str,
-    excluded_files: Set[str] = None,
-    excluded_folders: Set[str] = None,
-    file_extensions: Set[str] = None,
-    exclude_dot_files: bool = False,
-    exclude_hidden_files: bool = True,
-):
+def file_matches_criteria(root: str,
+                          file: str,
+                          excluded_files: Set[str] = None,
+                          excluded_folders: Set[str] = None,
+                          file_extensions: Set[str] = None,
+                          exclude_dot_files: bool = False,
+                          exclude_hidden_files: bool = True):
     if excluded_folders is None:
         excluded_folders = {}
     relative_path = os.path.relpath(file, root)
-    if any(
-        relative_path.startswith(excluded_folder)
-        for excluded_folder in excluded_folders
-    ):
+    if any(relative_path.startswith(excluded_folder) for excluded_folder in excluded_folders):
         return False
     if excluded_files is not None and relative_path in excluded_files:
         return False
     filename = os.path.basename(file)
-    if exclude_dot_files and filename.startswith("."):
+    if exclude_dot_files and filename.startswith('.'):
         return False
-    if (
-        file_extensions is not None
-        and pathlib.Path(filename).suffix not in file_extensions
-    ):
+    if file_extensions is not None and pathlib.Path(filename).suffix not in file_extensions:
         return False
     if exclude_hidden_files and _is_hidden_file(file):
         return False
@@ -561,46 +436,34 @@ def file_matches_criteria(
 
 def _is_hidden_file(full_path):
     def is_windows():
-        return os.name == "nt"
+        return os.name == 'nt'
 
     def has_hidden_attribute(file_path):
-        return is_windows() and bool(
-            os.stat(file_path).st_file_attributes & FILE_ATTRIBUTE_HIDDEN
-        )
+        return is_windows() and bool(os.stat(file_path).st_file_attributes & FILE_ATTRIBUTE_HIDDEN)
 
     try:
-        return os.path.basename(full_path).startswith(".") or has_hidden_attribute(
-            full_path
-        )
+        return os.path.basename(full_path).startswith('.') or has_hidden_attribute(full_path)
     except FileNotFoundError:
         return False
 
 
-def find_files_in_folder_recursively(
-    root: str,
-    excluded_files: Set[str] = None,
-    excluded_folders: Set[str] = None,
-    file_extensions: Set[str] = None,
-    exclude_dot_files: bool = False,
-    exclude_hidden_files: bool = True,
-):
+def find_files_in_folder_recursively(root: str,
+                                     excluded_files: Set[str] = None,
+                                     excluded_folders: Set[str] = None,
+                                     file_extensions: Set[str] = None,
+                                     exclude_dot_files: bool = False,
+                                     exclude_hidden_files: bool = True):
     if excluded_folders is None:
         excluded_folders = {}
     files_to_deploy = list()
-    for dir_path, _, files in os.walk(root):
+    for (dir_path, _, files) in os.walk(root):
         relative_dir_path = os.path.relpath(dir_path, root)
-        if any(
-            relative_dir_path.startswith(excluded_folder)
-            for excluded_folder in excluded_folders
-        ):
+        if any(relative_dir_path.startswith(excluded_folder) for excluded_folder in excluded_folders):
             continue
         for filename in files:
-            if exclude_dot_files and filename.startswith("."):
+            if exclude_dot_files and filename.startswith('.'):
                 continue
-            if (
-                file_extensions is not None
-                and pathlib.Path(filename).suffix not in file_extensions
-            ):
+            if file_extensions is not None and pathlib.Path(filename).suffix not in file_extensions:
                 continue
             full_path = os.path.join(dir_path, filename)
             if exclude_hidden_files and _is_hidden_file(full_path):
@@ -613,9 +476,9 @@ def find_files_in_folder_recursively(
 
 
 def _shut_down_kernel(url: str, requests_session, auth_header, project_id):
-    shut_down_endpoint = f"{url}/data-lab/{project_id}/functions/shutdown"
+    shut_down_endpoint = f'{url}/data-lab/{project_id}/functions/shutdown'
     requests_session.post(shut_down_endpoint, headers=auth_header, cookies=auth_header)
 
 
 def _get_jupyter_contents_api_path(url, project_id, path):
-    return f"{url}/data-lab/{project_id}/api/contents/" + path.replace("\\", "//")
+    return f'{url}/data-lab/{project_id}/api/contents/' + path.replace('\\', '//')

--- a/addon_template/_dev_tools/addon_tasks/utils.py
+++ b/addon_template/_dev_tools/addon_tasks/utils.py
@@ -13,40 +13,50 @@ from stat import FILE_ATTRIBUTE_HIDDEN
 from _dev_tools.addon_tasks.element_protocol import ElementProtocol
 
 PROJECT_PATH = pathlib.Path(__file__).parent.parent.parent.resolve()
-WHEELS_PATH = PROJECT_PATH / '.wheels'
-DIST_FOLDER = PROJECT_PATH / 'dist'
+WHEELS_PATH = PROJECT_PATH / ".wheels"
+DIST_FOLDER = PROJECT_PATH / "dist"
 ADDON_JSON_FILE = PROJECT_PATH / "addon.json"
-ADD_ON_EXTENSION = '.addon'
+ADD_ON_EXTENSION = ".addon"
 CREDENTIALS_JSON_FILE = PROJECT_PATH / ".credentials.json"
 
-ELEMENT_ACTION_FILE = 'element'
+ELEMENT_ACTION_FILE = "element"
 
 IDENTIFIER = "identifier"
-VERSION = 'version'
-ELEMENTS = 'elements'
-ELEMENT_PATH = 'path'
-ELEMENT_TYPE = 'type'
-ELEMENT_IDENTIFIER = 'identifier'
+VERSION = "version"
+ELEMENTS = "elements"
+ELEMENT_PATH = "path"
+ELEMENT_TYPE = "type"
+ELEMENT_IDENTIFIER = "identifier"
 CONFIGURATION_SCHEMA = "configuration_schema"
 PREVIEWS = "previews"
 
 ADD_ON_TOOL_TYPE = "AddOnTool"
-DEFAULT_ADD_ON_TOOL_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project'
+DEFAULT_ADD_ON_TOOL_ELEMENT_PATH = (
+    f"{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project"
+)
 DISPLAY_PANE_PLUGIN_TYPE = "Plugin"
-DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.plugin'
+DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH = (
+    f"{pathlib.Path(__file__).parent.parent.name}.defaults.plugin"
+)
 TOOL_PANE_PLUGIN_TYPE = "Plugin"
-DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.plugin'
+DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH = (
+    f"{pathlib.Path(__file__).parent.parent.name}.defaults.plugin"
+)
 FORMULA_PACKAGE_TYPE = "FormulaPackage"
-DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.formula_package'
+DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH = (
+    f"{pathlib.Path(__file__).parent.parent.name}.defaults.formula_package"
+)
 DATA_LAB_FUNCTIONS_TYPE = "DataLabFunctions"
-DATA_LAB_FUNCTIONS_ELEMENT_PATH = f'{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project'
+DATA_LAB_FUNCTIONS_ELEMENT_PATH = (
+    f"{pathlib.Path(__file__).parent.parent.name}.defaults.data_lab_project"
+)
 
-TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 NOTE_FOR_FEATURE_FLAG_CHANGE = "Enabled by Add-on Packaging Utility"
 
 
 def save_json(path: pathlib.Path, values: dict) -> None:
-    with open(path, mode='w', encoding='utf-8') as json_file:
+    with open(path, mode="w", encoding="utf-8") as json_file:
         json.dump(values, json_file, indent=2, ensure_ascii=False)
 
 
@@ -54,10 +64,10 @@ def load_json(path: pathlib.Path) -> Optional[dict]:
     if not path.exists():
         return None
     try:
-        with open(path, mode='r', encoding='utf-8') as json_file:
+        with open(path, mode="r", encoding="utf-8") as json_file:
             return json.load(json_file)
     except json.JSONDecodeError:
-        raise Exception(f'Error loading JSON file: {path}')
+        raise Exception(f"Error loading JSON file: {path}")
 
 
 def get_credentials_json() -> Optional[dict]:
@@ -88,35 +98,47 @@ def get_module(element_path: str, element_type: str) -> ElementProtocol:
         if path in sys.modules:
             return sys.modules[path]
         return importlib.import_module(path)
+
     try:
-        module = load_module(f'{element_path}.{ELEMENT_ACTION_FILE}')
+        module = load_module(f"{element_path}.{ELEMENT_ACTION_FILE}")
         assert isinstance(module, ElementProtocol)
         return module
     except ModuleNotFoundError:
         if element_type == ADD_ON_TOOL_TYPE:
-            module = load_module(f"{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
+            module = load_module(
+                f"{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
+            )
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == FORMULA_PACKAGE_TYPE:
-            module = load_module(f"{DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
+            module = load_module(
+                f"{DEFAULT_FORMULA_PACKAGE_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
+            )
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == DISPLAY_PANE_PLUGIN_TYPE:
-            module = load_module(f"{DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
+            module = load_module(
+                f"{DEFAULT_DISPLAY_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
+            )
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == TOOL_PANE_PLUGIN_TYPE:
-            module = load_module(f"{DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
+            module = load_module(
+                f"{DEFAULT_TOOL_PANE_PLUGIN_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
+            )
             assert isinstance(module, ElementProtocol)
             return module
         elif element_type == DATA_LAB_FUNCTIONS_TYPE:
-            module = load_module(f"{DATA_LAB_FUNCTIONS_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}")
+            module = load_module(
+                f"{DATA_LAB_FUNCTIONS_ELEMENT_PATH}.{ELEMENT_ACTION_FILE}"
+            )
             assert isinstance(module, ElementProtocol)
             return module
         else:
             raise ModuleNotFoundError(
-                f'Neither {element_path}.{ELEMENT_ACTION_FILE} nor '
-                f'{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE} were found')
+                f"Neither {element_path}.{ELEMENT_ACTION_FILE} nor "
+                f"{DEFAULT_ADD_ON_TOOL_ELEMENT_PATH}.{ELEMENT_ACTION_FILE} were found"
+            )
 
 
 def get_folders_from_args(args) -> Optional[List[str]]:
@@ -124,7 +146,7 @@ def get_folders_from_args(args) -> Optional[List[str]]:
         return None
     for folder in args.dir:
         if not (PROJECT_PATH / pathlib.Path(folder)).exists():
-            raise Exception(f'Folder does not exist: {folder}')
+            raise Exception(f"Folder does not exist: {folder}")
     return [str(pathlib.Path(folder)) for folder in args.dir]
 
 
@@ -132,10 +154,13 @@ def get_element_paths_with_type() -> Dict[str, str]:
     add_on_json = get_add_on_json()
     if add_on_json is None or ELEMENTS not in add_on_json:
         return {}
-    element_paths = {element.get(ELEMENT_PATH): element.get(ELEMENT_TYPE) for element in add_on_json.get(ELEMENTS)}
+    element_paths = {
+        element.get(ELEMENT_PATH): element.get(ELEMENT_TYPE)
+        for element in add_on_json.get(ELEMENTS)
+    }
     for element_path in element_paths:
         if not pathlib.Path(element_path).exists():
-            raise Exception(f'Element path does not exist: {element_path}')
+            raise Exception(f"Element path does not exist: {element_path}")
     return element_paths
 
 
@@ -148,10 +173,10 @@ def get_files_to_package() -> List[str]:
 def parse_url_username_password(args=None):
     credentials_json = {}
     if (
-            args is None
-            or args.username is None
-            or args.password is None
-            or args.url is None
+        args is None
+        or args.username is None
+        or args.password is None
+        or args.url is None
     ):
         credentials_json = get_credentials_json()
         if credentials_json is None:
@@ -185,11 +210,17 @@ def get_element_identifier_from_path(element_path: pathlib.Path) -> str:
     )
 
 
-def filter_element_paths(element_paths_with_type: Optional[Dict[str, str]], subset_folders: Optional[List[str]]):
+def filter_element_paths(
+    element_paths_with_type: Optional[Dict[str, str]],
+    subset_folders: Optional[List[str]],
+):
     if subset_folders is None:
         return element_paths_with_type
-    return {element_path: element_type for element_path, element_type in element_paths_with_type.items()
-            if element_path in subset_folders}
+    return {
+        element_path: element_type
+        for element_path, element_type in element_paths_with_type.items()
+        if element_path in subset_folders
+    }
 
 
 def topological_sort(graph: Dict[str, List[str]]) -> List[str]:
@@ -265,6 +296,7 @@ def generate_schema_default_dict(schema, path=""):
 
 def check_feature_is_enabled(url, username, password, feature_path):
     from seeq import sdk, spy
+
     spy.login(username=username, password=password, url=url, quiet=True)
     system_api = sdk.SystemApi(spy.client)
     response = system_api.get_server_status()
@@ -273,28 +305,34 @@ def check_feature_is_enabled(url, username, password, feature_path):
             if option.value is False:
                 if spy.user.is_admin:
                     print(f"Feature {feature_path} is not enabled. Enabling it now.")
-                    system_api.set_configuration_options(body={
-                        "configurationOptions": [
-                            {
-                                "note": NOTE_FOR_FEATURE_FLAG_CHANGE,
-                                "path": feature_path,
-                                "value": True
-                            }
-                        ],
-                        "dryRun": False
-                    })
+                    system_api.set_configuration_options(
+                        body={
+                            "configurationOptions": [
+                                {
+                                    "note": NOTE_FOR_FEATURE_FLAG_CHANGE,
+                                    "path": feature_path,
+                                    "value": True,
+                                }
+                            ],
+                            "dryRun": False,
+                        }
+                    )
                 else:
                     raise ValueError(
-                        f"Feature {feature_path} is not enabled. Please contact your Seeq administrator to enable it")
+                        f"Feature {feature_path} is not enabled. Please contact your Seeq administrator to enable it"
+                    )
 
 
 def _get_authenticated_session(element_path, url, username, password):
     from seeq import sdk, spy
+
     spy.login(username=username, password=password, url=url, quiet=True)
-    auth_header = {'sq-auth': spy.client.auth_token}
+    auth_header = {"sq-auth": spy.client.auth_token}
     items_api = sdk.ItemsApi(spy.client)
     element_project_name = get_element_identifier_from_path(element_path)
-    response = items_api.search_items(filters=[f'name=={element_project_name}'], types=['Project'])
+    response = items_api.search_items(
+        filters=[f"name=={element_project_name}"], types=["Project"]
+    )
     if len(response.items) == 0:
         raise Exception(f"Could not find a project with name {element_project_name}")
     project_id = response.items[0].id
@@ -305,39 +343,65 @@ def _get_authenticated_session(element_path, url, username, password):
 def _create_requests_session():
     import requests
     from requests.adapters import HTTPAdapter, Retry
+
     max_request_retries = 5
     request_retry_status_list = [502, 503, 504]
     _http_adapter = HTTPAdapter(
-        max_retries=Retry(total=max_request_retries, backoff_factor=0.5, status_forcelist=request_retry_status_list))
+        max_retries=Retry(
+            total=max_request_retries,
+            backoff_factor=0.5,
+            status_forcelist=request_retry_status_list,
+        )
+    )
     request_session = requests.Session()
     request_session.mount("http://", _http_adapter)
     request_session.mount("https://", _http_adapter)
     return request_session
 
 
-def _upload_file(server_url, request_session, auth_header, project_id, source, destination):
+def _upload_file(
+    server_url, request_session, auth_header, project_id, source, destination
+):
     from requests.exceptions import RetryError
 
     jupyter_path = _get_jupyter_contents_api_path(server_url, project_id, destination)
     base_name = os.path.basename(source)
-    with open(source, 'rb') as file:
-        contents = file.read() or b''
-    body = json.dumps({'path': jupyter_path.replace('//', r'/'),
-                       'content': base64.b64encode(contents).decode('ascii'),
-                       'format': 'base64',
-                       'name': base_name,
-                       'type': 'file'})
+    with open(source, "rb") as file:
+        contents = file.read() or b""
+    body = json.dumps(
+        {
+            "path": jupyter_path.replace("//", r"/"),
+            "content": base64.b64encode(contents).decode("ascii"),
+            "format": "base64",
+            "name": base_name,
+            "type": "file",
+        }
+    )
     response = None
     try:
-        response = request_session.put(jupyter_path, data=body, headers=auth_header, cookies=auth_header,
-                                       verify=True, timeout=60)
+        response = request_session.put(
+            jupyter_path,
+            data=body,
+            headers=auth_header,
+            cookies=auth_header,
+            verify=True,
+            timeout=60,
+        )
     except RetryError:
         pass
     if response is None or response.status_code == 500:
-        _upload_directory(server_url, request_session, auth_header, project_id, destination)
+        _upload_directory(
+            server_url, request_session, auth_header, project_id, destination
+        )
         try:
-            response = request_session.put(jupyter_path, data=body, headers=auth_header, cookies=auth_header,
-                                           verify=True, timeout=60)
+            response = request_session.put(
+                jupyter_path,
+                data=body,
+                headers=auth_header,
+                cookies=auth_header,
+                verify=True,
+                timeout=60,
+            )
         except RetryError:
             pass
 
@@ -347,46 +411,85 @@ def _upload_file(server_url, request_session, auth_header, project_id, source, d
 
 def _upload_directory(server_url, request_session, auth_header, project_id, full_path):
     from requests.exceptions import RetryError
+
     path_parts = pathlib.Path(full_path).parts
     paths_to_create = [list(path_parts[:i]) for i in range(1, len(path_parts))]
-    body = json.dumps({'type': 'directory'})
-    base = [server_url, 'data-lab', project_id, 'api', 'contents']
+    body = json.dumps({"type": "directory"})
+    base = [server_url, "data-lab", project_id, "api", "contents"]
     for path in paths_to_create:
         try:
-            request_session.put('/'.join(base + path), data=body,
-                                headers=auth_header, cookies=auth_header,
-                                verify=True, timeout=60)
+            request_session.put(
+                "/".join(base + path),
+                data=body,
+                headers=auth_header,
+                cookies=auth_header,
+                verify=True,
+                timeout=60,
+            )
         except RetryError:
             pass
 
 
-def _delete_file(server_url, request_session, auth_header, project_id, source, destination):
+def _delete_file(
+    server_url, request_session, auth_header, project_id, source, destination
+):
     from requests.exceptions import RetryError
+
     base_name = os.path.basename(source)
     jupyter_path = _get_jupyter_contents_api_path(server_url, project_id, destination)
     response = None
     try:
-        response = request_session.delete(jupyter_path,
-                                          headers=auth_header, cookies=auth_header,
-                                          verify=True, timeout=60)
+        response = request_session.delete(
+            jupyter_path,
+            headers=auth_header,
+            cookies=auth_header,
+            verify=True,
+            timeout=60,
+        )
     except RetryError:
         pass
     status = "Success" if (response is not None) else "Failure"
     print(f"    {_get_timestamp()} Attempt to delete {base_name} : {status}")
 
 
-async def _watch_from_environment(element_path: pathlib.Path, url: str, username: str, password: str,
-                                  file_extensions: set, excluded_files: set, excluded_folders: set):
+async def _watch_from_environment(
+    element_path: pathlib.Path,
+    url: str,
+    username: str,
+    password: str,
+    file_extensions: set,
+    excluded_files: set,
+    excluded_folders: set,
+):
     print(f"Watching {element_path}")
-    await asyncio.gather(hot_reload(element_path, url, username, password,
-                                    file_extensions, excluded_files, excluded_folders))
+    await asyncio.gather(
+        hot_reload(
+            element_path,
+            url,
+            username,
+            password,
+            file_extensions,
+            excluded_files,
+            excluded_folders,
+        )
+    )
 
 
-async def hot_reload(element_path: pathlib.Path, url: str, username: str, password: str,
-                     file_extensions: set, excluded_files: set, excluded_folders: set):
+async def hot_reload(
+    element_path: pathlib.Path,
+    url: str,
+    username: str,
+    password: str,
+    file_extensions: set,
+    excluded_files: set,
+    excluded_folders: set,
+):
 
     from watchfiles import awatch, Change
-    requests_session, auth_header, project_id = _get_authenticated_session(element_path, url, username, password)
+
+    requests_session, auth_header, project_id = _get_authenticated_session(
+        element_path, url, username, password
+    )
     async for changes in awatch(element_path):
         for change in changes:
             if isdir(change[1]):
@@ -396,38 +499,60 @@ async def hot_reload(element_path: pathlib.Path, url: str, username: str, passwo
             absolute_file_path = change[1]
             destination = relpath(absolute_file_path, element_path)
 
-            if file_matches_criteria(str(element_path),
-                                     absolute_file_path,
-                                     file_extensions=file_extensions,
-                                     excluded_files=excluded_files,
-                                     excluded_folders=excluded_folders):
+            if file_matches_criteria(
+                str(element_path),
+                absolute_file_path,
+                file_extensions=file_extensions,
+                excluded_files=excluded_files,
+                excluded_folders=excluded_folders,
+            ):
                 if deleted:
-                    _delete_file(url, requests_session, auth_header, project_id,
-                                 absolute_file_path, destination)
+                    _delete_file(
+                        url,
+                        requests_session,
+                        auth_header,
+                        project_id,
+                        absolute_file_path,
+                        destination,
+                    )
                 else:
-                    _upload_file(url, requests_session, auth_header, project_id,
-                                 absolute_file_path, destination)
+                    _upload_file(
+                        url,
+                        requests_session,
+                        auth_header,
+                        project_id,
+                        absolute_file_path,
+                        destination,
+                    )
                 _shut_down_kernel(url, requests_session, auth_header, project_id)
 
 
-def file_matches_criteria(root: str,
-                          file: str,
-                          excluded_files: Set[str] = None,
-                          excluded_folders: Set[str] = None,
-                          file_extensions: Set[str] = None,
-                          exclude_dot_files: bool = False,
-                          exclude_hidden_files: bool = True):
+def file_matches_criteria(
+    root: str,
+    file: str,
+    excluded_files: Set[str] = None,
+    excluded_folders: Set[str] = None,
+    file_extensions: Set[str] = None,
+    exclude_dot_files: bool = False,
+    exclude_hidden_files: bool = True,
+):
     if excluded_folders is None:
         excluded_folders = {}
     relative_path = os.path.relpath(file, root)
-    if any(relative_path.startswith(excluded_folder) for excluded_folder in excluded_folders):
+    if any(
+        relative_path.startswith(excluded_folder)
+        for excluded_folder in excluded_folders
+    ):
         return False
     if excluded_files is not None and relative_path in excluded_files:
         return False
     filename = os.path.basename(file)
-    if exclude_dot_files and filename.startswith('.'):
+    if exclude_dot_files and filename.startswith("."):
         return False
-    if file_extensions is not None and pathlib.Path(filename).suffix not in file_extensions:
+    if (
+        file_extensions is not None
+        and pathlib.Path(filename).suffix not in file_extensions
+    ):
         return False
     if exclude_hidden_files and _is_hidden_file(file):
         return False
@@ -436,34 +561,46 @@ def file_matches_criteria(root: str,
 
 def _is_hidden_file(full_path):
     def is_windows():
-        return os.name == 'nt'
+        return os.name == "nt"
 
     def has_hidden_attribute(file_path):
-        return is_windows() and bool(os.stat(file_path).st_file_attributes & FILE_ATTRIBUTE_HIDDEN)
+        return is_windows() and bool(
+            os.stat(file_path).st_file_attributes & FILE_ATTRIBUTE_HIDDEN
+        )
 
     try:
-        return os.path.basename(full_path).startswith('.') or has_hidden_attribute(full_path)
+        return os.path.basename(full_path).startswith(".") or has_hidden_attribute(
+            full_path
+        )
     except FileNotFoundError:
         return False
 
 
-def find_files_in_folder_recursively(root: str,
-                                     excluded_files: Set[str] = None,
-                                     excluded_folders: Set[str] = None,
-                                     file_extensions: Set[str] = None,
-                                     exclude_dot_files: bool = False,
-                                     exclude_hidden_files: bool = True):
+def find_files_in_folder_recursively(
+    root: str,
+    excluded_files: Set[str] = None,
+    excluded_folders: Set[str] = None,
+    file_extensions: Set[str] = None,
+    exclude_dot_files: bool = False,
+    exclude_hidden_files: bool = True,
+):
     if excluded_folders is None:
         excluded_folders = {}
     files_to_deploy = list()
-    for (dir_path, _, files) in os.walk(root):
+    for dir_path, _, files in os.walk(root):
         relative_dir_path = os.path.relpath(dir_path, root)
-        if any(relative_dir_path.startswith(excluded_folder) for excluded_folder in excluded_folders):
+        if any(
+            relative_dir_path.startswith(excluded_folder)
+            for excluded_folder in excluded_folders
+        ):
             continue
         for filename in files:
-            if exclude_dot_files and filename.startswith('.'):
+            if exclude_dot_files and filename.startswith("."):
                 continue
-            if file_extensions is not None and pathlib.Path(filename).suffix not in file_extensions:
+            if (
+                file_extensions is not None
+                and pathlib.Path(filename).suffix not in file_extensions
+            ):
                 continue
             full_path = os.path.join(dir_path, filename)
             if exclude_hidden_files and _is_hidden_file(full_path):
@@ -476,9 +613,9 @@ def find_files_in_folder_recursively(root: str,
 
 
 def _shut_down_kernel(url: str, requests_session, auth_header, project_id):
-    shut_down_endpoint = f'{url}/data-lab/{project_id}/functions/shutdown'
+    shut_down_endpoint = f"{url}/data-lab/{project_id}/functions/shutdown"
     requests_session.post(shut_down_endpoint, headers=auth_header, cookies=auth_header)
 
 
 def _get_jupyter_contents_api_path(url, project_id, path):
-    return f'{url}/data-lab/{project_id}/api/contents/' + path.replace('\\', '//')
+    return f"{url}/data-lab/{project_id}/api/contents/" + path.replace("\\", "//")

--- a/addon_template/_dev_tools/utils.py
+++ b/addon_template/_dev_tools/utils.py
@@ -1,9 +1,10 @@
 import os
+import sys
 import subprocess
 import pathlib
 import venv
 
-
+MIN_PYTHON_VERSION = (3, 11)
 VENV_NAME = ".venv"
 WHEELS_NAME = ".wheels"
 
@@ -105,3 +106,14 @@ def update_venv(element_path: pathlib.Path, global_path: pathlib.Path = None, hi
     pip_install_dependencies(element_path, path_to_pip, wheels_path, hide_stdout=hide_stdout)
 
     print("Virtual environment updated.")
+
+
+def check_python_version(major, minor):
+    python_version = sys.version_info
+    if python_version < (major, minor):
+        raise Exception(
+            f"Python {major}.{minor} or higher is required. Found {python_version.major}.{python_version.minor}.{python_version.micro}"
+        )
+    print(
+        f"Python version: {python_version.major}.{python_version.minor}.{python_version.micro}"
+    )

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,6 +1,10 @@
 import sys
 from pathlib import Path
-from addon_template._dev_tools.utils import create_virtual_environment
+from addon_template._dev_tools.utils import (
+    create_virtual_environment,
+    check_python_version,
+    MIN_PYTHON_VERSION,
+)
 
 
 PROJECT_PATH = Path(__file__).parent.resolve()
@@ -9,4 +13,5 @@ PROJECT_PATH = Path(__file__).parent.resolve()
 path = sys.argv[1] if len(sys.argv) > 1 else None
 if path:
     PROJECT_PATH = Path(path).resolve()
+check_python_version(*MIN_PYTHON_VERSION)
 create_virtual_environment(PROJECT_PATH, clean=True, hide_stdout=True)


### PR DESCRIPTION
Bootstrapping an element requires Python 3.11; update the readme to reflect this.

We should also verify python version prior to creating the `.sq-addon` venv to prevent users from installing the templating utility with an unsupported python version.