### PR TITLE
CRAB-46747: Add-on Tools from template don't include query parameters

### DIFF
--- a/addon_template/addon_example/addon.json.jinja
+++ b/addon_template/addon_example/addon.json.jinja
@@ -45,13 +45,23 @@
               "windowDetails": {
                 "type": "string",
                 "default": "{{ addOnTool_window_details }}"
+              },
+              "reuseWindow": {
+                "type": "boolean",
+                "default": true
+              },
+              "includeWorkbookParameters": {
+                "type": "boolean",
+                "default": true
               }
             },
             "required": [
               "icon",
               "linkType",
               "sortKey",
-              "windowDetails"
+              "windowDetails",
+              "reuseWindow",
+              "includeWorkbookParameters"
             ]
           },
           "project": {


### PR DESCRIPTION
This PR adds the `reuseWindow` and `includeWorkbookParameters` defaults to the AddOn Tool display properties in the `addon.json` file. They should have defaulted to true on deployment, but this ensures the value can be modified.